### PR TITLE
Switch the order of arguments passed to Ormolu.

### DIFF
--- a/ormolu.el
+++ b/ormolu.el
@@ -56,7 +56,7 @@
 ;;;###autoload (autoload 'ormolu-format-on-save-mode "ormolu" nil t)
 (reformatter-define ormolu-format
   :program ormolu-process-path
-  :args (append '("/dev/stdin") ormolu-extra-args)
+  :args (append ormolu-extra-args (list "/dev/stdin"))
   :group 'ormolu
   :lighter " Or"
   :keymap ormolu-mode-map)


### PR DESCRIPTION
For some projects, we don't call Ormolu directly, but rather have it managed by
our build tool (e.g., bazel) in order to make sure things like all the
project-wide language extensions are passed to Ormolu when we run it. As a
consequence, I have something like the following in my dir-locals for one of my
projects:

```emacs-lisp
(ormolu-extra-args . ("run" "//build/rule/lint:run_ormolu" "--" "--mode" "passthrough"))
(ormolu-process-path . "bazel")
```

With the existing location of `ormolu-extra-args`, this doesn't work, because
`"/dev/stdin"` gets passed to `bazel` instead of `ormolu`. This change fixes
that. (Also, the change from `'` to `list` is because the final argument to
`append` isn't copied, so it's dangerous to use a literal in that position.)