### PR TITLE
Extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ormolu.el
 
-Format Haskell source code using [ormolu](https://github.com/tweag/ormolu).
+Format Haskell source code using [ormolu](https://github.com/tweag/ormolu).  Requires [reformatter.el](https://github.com/purcell/reformatter.el).
 
 # Usage
 
@@ -12,4 +12,13 @@ With [use-package](https://github.com/jwiegley/use-package/):
  :config
  (:map haskell-mode-map
    ("C-c r" . ormolu-format-buffer)))
+```
+
+Without:
+
+```elisp
+(push "~/.elib/contrib/reformatter.el" load-path)
+(push "~/.elib/contrib/ormolu.el" load-path)
+(load-library "ormolu")
+(add-hook 'haskell-mode-hook 'ormolu-format-on-save-mode)
 ```


### PR DESCRIPTION
- alternative usage without `use-package`.
- mention reformatter dependency.

Thanks for this!  :)