### PR TITLE
Removes explicit /dev/stdin input path

### DIFF
--- a/ormolu.el
+++ b/ormolu.el
@@ -56,7 +56,7 @@
 ;;;###autoload (autoload 'ormolu-format-on-save-mode "ormolu" nil t)
 (reformatter-define ormolu-format
   :program ormolu-process-path
-  :args (append ormolu-extra-args (list "/dev/stdin"))
+  :args ormolu-extra-args
   :group 'ormolu
   :lighter " Or"
   :keymap ormolu-mode-map)


### PR DESCRIPTION
Since at least version 0.0.1.0, `ormolu` has assumed that if it's called with no arguments it should read from `stdin`.

I ran into an issue today where Emacs didn't necessarily have the correct permissions for reading from `/dev/stdin` on my system, which caused `ormolu.el` to clear the entire buffer on format.

`ormolu` also accepts `"-"` as an argument to indicate that it should read from stdin, if you think that would be a bit more explicit.