### PR TITLE
Support Ormolu 0.5.0.0

### DIFF
--- a/ormolu.el
+++ b/ormolu.el
@@ -48,8 +48,8 @@
   :type 'sexp
   :safe #'listp)
 
-(defcustom ormolu-cabal-default-extensions nil
-  "Whether to use the --cabal-default-extensions flag."
+(defcustom ormolu-no-cabal nil
+  "Whether to use the --no-cabal flag."
   :group 'ormolu
   :type 'boolean
   :safe #'booleanp)
@@ -62,9 +62,9 @@
 ;;;###autoload (autoload 'ormolu-format-on-save-mode "ormolu" nil t)
 (reformatter-define ormolu-format
   :program ormolu-process-path
-  :args (append (if (and ormolu-cabal-default-extensions buffer-file-name)
-                    `("--cabal-default-extensions" "--stdin-input-file" ,buffer-file-name)
-                  '()) ormolu-extra-args)
+  :args (append (if (and (not ormolu-no-cabal) buffer-file-name)
+                    `("--stdin-input-file" ,buffer-file-name)
+                  '("--no-cabal")) ormolu-extra-args)
   :group 'ormolu
   :lighter " Or"
   :keymap ormolu-mode-map)


### PR DESCRIPTION
Starting with 0.5.0.0 ([changelog](https://github.com/tweag/ormolu/blob/master/CHANGELOG.md#ormolu-0500=)), Ormolu requires the `--stdin-input-file` when reading from stdin by default, unless one passes `--no-cabal`.

Note that this breaks support with Ormolu <0.5.0.0. We *could* add a  flag to support older versions, but I am not sure if that is worth it.